### PR TITLE
Temporary fix for /auth/register user profile validation

### DIFF
--- a/app/client/src/services/AuthService.js
+++ b/app/client/src/services/AuthService.js
@@ -60,6 +60,7 @@ angular.module('reg')
       };
 
       authService.register = function(email, password, profile, onSuccess, onFailure) {
+        profile.name = profile.firstname + ' ' + profile.lastname;
         return $http
           .post('/auth/register', {
             email: email,
@@ -74,7 +75,8 @@ angular.module('reg')
           });
       };
 
-      authService.createAccount = function(email, password, onSuccess, onFailure) {
+      authService.createAccount = function(email, password, profile, onSuccess, onFailure) {
+        profile.name = profile.firstname + ' ' + profile.lastname;
         return $http
           .post('/auth/register', {
             email: email,

--- a/app/client/src/services/AuthService.js
+++ b/app/client/src/services/AuthService.js
@@ -59,11 +59,12 @@ angular.module('reg')
         $state.go('app.login');
       };
 
-      authService.register = function(email, password, onSuccess, onFailure) {
+      authService.register = function(email, password, profile, onSuccess, onFailure) {
         return $http
           .post('/auth/register', {
             email: email,
-            password: password
+            password: password,
+            profile: profile
           })
           .success(function(data){
             loginSuccess(data, onSuccess);
@@ -77,7 +78,8 @@ angular.module('reg')
         return $http
           .post('/auth/register', {
             email: email,
-            password: password
+            password: password,
+            profile: profile
           })
           .success(function(data){
             return onSuccess(data.user);

--- a/app/client/views/apply/applyCtrl.js
+++ b/app/client/views/apply/applyCtrl.js
@@ -129,7 +129,7 @@ angular.module('reg')
       }
 
       function _apply(e){
-        AuthService.register($scope.user.email, $scope.user.password, function success(data) {
+        AuthService.register($scope.user.email, $scope.user.password, $scope.user.profile, function success(data) {
           UserService
             .updateProfile(Session.getUserId(), $scope.user.profile)
             .success(function(data){

--- a/app/client/views/checkin/checkinCtrl.js
+++ b/app/client/views/checkin/checkinCtrl.js
@@ -182,7 +182,7 @@ angular.module('reg')
       };
 
       function _apply(e){
-        AuthService.createAccount($scope.newUser.email, $scope.newUser.password, function success(user) {
+        AuthService.createAccount($scope.newUser.email, $scope.newUser.password, $scope.newUser.profile, function success(user) {
           UserService
             .updateProfile(user.id, $scope.newUser.profile)
             .success(function(data){

--- a/app/client/views/login/loginCtrl.js
+++ b/app/client/views/login/loginCtrl.js
@@ -37,7 +37,7 @@ angular.module('reg')
       $scope.register = function(){
         resetError();
         AuthService.register(
-          $scope.email, $scope.password, onSuccess, onError);
+          $scope.email, $scope.password, $scope.user.profile, onSuccess, onError);
       };
 
       $scope.setLoginState = function(state) {

--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -129,13 +129,7 @@ UserController.createValidUser = function(email, password, profile, callback){
     if (err){
       return callback({message: 'invalid profile'});
     }
-    UserController.createUser(email, password,
-      function(err, user){
-        if (err){
-          return res.status(400).send(err);
-        }
-        return res.json(user);
-    });
+    UserController.createUser(email, password, callback);
   });
 }; 
 

--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -118,9 +118,31 @@ UserController.loginWithPassword = function(email, password, callback){
 };
 
 /**
+ * Creates and validates a new user given an email, password annd profile.
+ * @param  {String}   email    User's email.
+ * @param  {String}   password User's password
+ * @param  {Object}   profile  Profile object
+ * @param  {Function} callback args(err, user)
+ */
+UserController.createValidUser = function(email, password, profile, callback){
+  User.validateProfile(profile, function(err){
+    if (err){
+      return callback({message: 'invalid profile'});
+    }
+    UserController.createUser(email, password,
+      function(err, user){
+        if (err){
+          return res.status(400).send(err);
+        }
+        return res.json(user);
+    });
+  });
+}; 
+
+/**
  * Create a new user given an email and a password.
  * @param  {String}   email    User's email.
- * @param  {String}   password [description]
+ * @param  {String}   password User's password.
  * @param  {Function} callback args(err, user)
  */
 UserController.createUser = function(email, password, callback) {

--- a/app/server/controllers/UserController.js
+++ b/app/server/controllers/UserController.js
@@ -118,7 +118,7 @@ UserController.loginWithPassword = function(email, password, callback){
 };
 
 /**
- * Creates and validates a new user given an email, password annd profile.
+ * Creates and validates a new user given an email, password and profile.
  * @param  {String}   email    User's email.
  * @param  {String}   password User's password
  * @param  {Object}   profile  Profile object

--- a/app/server/routes/auth.js
+++ b/app/server/routes/auth.js
@@ -71,8 +71,9 @@ module.exports = function(router){
       // Register with an email and password
       var email = req.body.email;
       var password = req.body.password;
+      var profile = req.body.profile;
 
-      UserController.createUser(email, password,
+      UserController.createValidUser(email, password, profile,
         function(err, user){
           if (err){
             return res.status(400).send(err);


### PR DESCRIPTION
This is a quick fix that solves the issue in /auth/register, where an API request can be sent to create a user with an invalid profile
The back-end fix involves just passing the profile information to /auth/register and having the server validate it, before a user can be created. This means that the client now has to send the profile data twice, once when calling /auth/register to create the user, and again when calling /users/:id/profile to actually update. 
A more in depth future fix would involve altering front end logic along with back-end to have a single endpoint (such as altering /auth/register) to be responsible for both creating the user and updating the profile and resume, so that the client creates a user and fills in the profile in one transactional request
This approach (and the existing web portal) has the possibility that, in a event of a network issue, a user's application might end up having an empty profile, since creating a account and filling in a profile are separate requests. This PR though requires less front end coordination and CR, and in the meantime will remove the ability to just create a user by only passing an email and password.